### PR TITLE
Updates navigation alignment and button styles

### DIFF
--- a/_sass/buttons.scss
+++ b/_sass/buttons.scss
@@ -7,13 +7,17 @@
   border-radius: 50px;
   display: inline-block;
   text-transform: uppercase;
-  padding: 16px 30px 16px;
+  padding: 18px 30px 12px;
   margin: 5px;
 }
 
 .btn-dark {
   background-color: $dark-gray;
   color: $light-gray;
+
+  &:hover {
+    color: $background-primary;
+  }
 }
 
 .btn-light {

--- a/_sass/sidebar.scss
+++ b/_sass/sidebar.scss
@@ -8,7 +8,7 @@ nav {
 
 .nav-links {
   display: grid;
-  grid-template-columns: auto 100px 100px 100px 100px 100px 100px;
+  grid-template-columns: auto repeat(7, min-content);
   grid-template-rows: 120px;
   align-items: center;
   justify-items: center;
@@ -17,6 +17,10 @@ nav {
   list-style: none;
   margin: 0 50px;
   padding-left: 0;
+
+  li {
+    text-align: center;
+  }
 
   li:first-child {
     justify-self: left;
@@ -32,7 +36,7 @@ nav {
   li:not(:first-child) {
     // Hover border does not apply to logo
     a:hover {
-      border-bottom: 3px solid lighten($turing-secondary, 25%);;
+      border-bottom: 3px solid lighten($turing-secondary, 25%);
     }
   }
 
@@ -49,26 +53,13 @@ nav {
   border-bottom: 3px solid lighten($turing-secondary, 25%);
 }
 
-@media (max-width: $tablet-width) {
-  .nav-links {
-    margin: 0 35px;
-    font-size: 0.9rem;
-    grid-template-columns: auto 75px 75px 75px 150px;
-    grid-template-rows: 90px;
-
-    .home-logo-link img {
-      height: 55px;
-      width: 55px;
-    }
-  }
-}
-
-@media (max-width: $phone-width) {
+// Adjusts max-width to account for number of menu items
+@media (max-width: ($tablet-width + 85px)) {
   .nav-links {
     margin: 15px;
     font-size: 1rem;
     grid-template-columns: auto 200px;
-    grid-template-rows: 35px 35px 35px 55px;
+    grid-template-rows: auto;
     justify-items: right;
 
     li {


### PR DESCRIPTION
## Overview

This PR updates button and navigation styles to bring them into line with other Turing properties.

### Button Styling Updates

Buttons across [other Turing properties](https://frontend.turing.io/) are rendered as such:

![image](https://user-images.githubusercontent.com/4118615/108636065-3b817180-7440-11eb-87eb-c6053e12cc78.png)

Currently, on the Mentorship site, buttons are rendered with different `padding` and no `hover` styles:

![image](https://user-images.githubusercontent.com/4118615/108636124-91eeb000-7440-11eb-8243-d9166a814c1f.png)

This PR updates the padding of of the base `btn` class and adds `hover` styling to the `btn-dark` class.

### Navigation Items Updates

Currently, navigation items are rendering across multiple lines:

![image](https://user-images.githubusercontent.com/4118615/108636151-b77bb980-7440-11eb-91b6-41e9271d6d56.png)
 
This PR aligns these navigation items:

![image](https://user-images.githubusercontent.com/4118615/108636162-cb272000-7440-11eb-8e42-f1eecd09c286.png)
