### PR TITLE
Fix section rage bug

### DIFF
--- a/calendars/back_end_calendars.md
+++ b/calendars/back_end_calendars.md
@@ -4,7 +4,7 @@ title: Back End Calendars
 ---
 
 <section class="module-content" data-module="1">
-  <h2>Mod 1<h2>
+  <h2>Mod 1</h2>
 
   <div class="responsive-iframe-container">
     <div class='tablet'>

--- a/calendars/front_end_calendars.md
+++ b/calendars/front_end_calendars.md
@@ -4,7 +4,7 @@ title: Front End Calendars
 ---
 
 <section class="module-content" data-module="1">
-  <h2>Mod 1<h2>
+  <h2>Mod 1</h2>
 
   <div class="responsive-iframe-container">
     <div class='tablet'>


### PR DESCRIPTION
## Overview

There is a DOM issue on the ["Back End Calendars"](https://mentorship.turing.io/calendars/back_end_calendars.html) and ["Front End Calendars"](https://mentorship.turing.io/calendars/front_end_calendars.html) pages where a hanging `</section>` tag is visible as plain text.

## Fix

The issue was caused by a missing closing `</h2>` tag. This resulted in a DOM mismatch of opening and closing tags. The issue is more clear when comparing the **Mod 1** and **Mod 2** headers which both use `<h2>` tags, but are visually different sizes.

## Screenshots

**Hanging section rage**
> ![image](https://user-images.githubusercontent.com/24458700/113369848-9b144c00-931f-11eb-8deb-ec1452e37b09.png)

**Different sized headers**
> ![image](https://user-images.githubusercontent.com/24458700/113369984-f47c7b00-931f-11eb-95bd-cea6b60af7d9.png)

**Fixed headers and no section rage**
> ![image](https://user-images.githubusercontent.com/24458700/113370058-21309280-9320-11eb-83cc-4667d438ea72.png)