### PR TITLE
Index page organization

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -45,7 +45,7 @@ img {
   max-width: 100%;
 }
 
-a {
+a, a:link, a:visited {
   border-bottom: 2px solid lighten($medium-gray, 20);
   color: darken($turing-primary, 30);
   text-decoration: none;

--- a/_sass/dtr.scss
+++ b/_sass/dtr.scss
@@ -1,0 +1,6 @@
+.resource a:link,
+.resource a:visited {
+  color: darken($dark-gray, 10%);
+  text-decoration: none;
+  font-weight: 500;
+}

--- a/_sass/sidebar.scss
+++ b/_sass/sidebar.scss
@@ -8,7 +8,7 @@ nav {
 
 .nav-links {
   display: grid;
-  grid-template-columns: auto repeat(7, min-content);
+  grid-template-columns: auto repeat(7, max-content);
   grid-template-rows: 120px;
   align-items: center;
   justify-items: center;
@@ -19,6 +19,7 @@ nav {
   padding-left: 0;
 
   li {
+    padding: 0 4px;
     text-align: center;
   }
 
@@ -54,7 +55,7 @@ nav {
 }
 
 // Adjusts max-width to account for number of menu items
-@media (max-width: ($tablet-width + 85px)) {
+@media (max-width: ($tablet-width + 300px)) {
   .nav-links {
     margin: 15px;
     font-size: 1rem;

--- a/dtr/index.md
+++ b/dtr/index.md
@@ -3,39 +3,60 @@ layout: page
 title: Mentorship DTRs
 ---
 
-### DTR Templates
-DTR, or "define the relationship", is a term used often at Turing when referring to conversations held by two or more people working closely together intentionally defining their professional working relationship. We strongly encourage students to be at the center of their information, to help them get used to and comfortable with being vulnerable about their understanding and open when they are unsure of something.
+## DTR Templates
 
-These DTR templates aim to help mentors and mentees have intentional, clear conversations about expectations, schedules, and goals for the work they do together.
+**DTR**, or "**define the relationship**", is a term used often at Turing when referring to conversations held by two or more people working closely together intentionally defining their professional working relationship. We encourage students to be at the center of their information, to help them get used to and comfortable with being vulnerable about their understanding, and open when they are unsure of something.
 
-The questions outlined in the linked template documents below should be discussed together with your mentee, and mentors should expect that they will be leading the conversation.
+These DTR templates aim to help mentors and mentees have clear conversations about expectations, schedules, and goals for the work they do together. The questions outlined in the templates documents should be discussed together with your mentee, and mentors should expect that they will be leading the conversation.
 
-<section>
-  <a href="/dtr/module-kick-off-dtr.html" class="btn btn-dark">Module Kick-off DTR</a>
-  <a href="/dtr/module-exit-dtr.html" class="btn btn-dark">Module Exit DTR</a>
-</section>
+<ul>
+  <li class="resource">
+    <a href="/dtr/module-kick-off-dtr.html">Module Kick-off DTR</a>
+  </li>
+  <li class="resource">
+    <a href="/dtr/module-exit-dtr.html">Module Exit DTR</a>
+  </li>
+</ul>
 
-### Leading the Charge on Scheduling
+<p>
+  <br>
+</p>
 
-It is strongly suggested that mentors set clear expectations with their mentees around consistent meeting times.
+---
 
-Students at Turing are often overwhelmed by the workload, and may not proactively schedule time with a mentor, despite how beneficial that time together is. Students often cite a concern of taking up too much of their mentors time or not wanting to be an imposition on their mentor as reasons they don't reach out to schedule time with you. It is not unlikely that you communicate to them several times that you _want_ to meet with them before they truly absorb it.
+## Leading the Charge on Scheduling
 
-Please do not be discouraged if you find that you are leading the charge when it comes to coordinating meetings. The relationship a student builds with their mentor is incredibly valuable, and they may need clear and direct encouragement from you, their mentor, that it is ok to regularly prioritize time spent working with and talking to you.
+Students at Turing are often overwhelmed by the workload, and may not proactively schedule time with a mentor. Students often cite a concern of taking up too much of their mentors time or not wanting to be an imposition. It is not unlikely that you communicate to them several times that you _want_ to meet with them before they truly absorb it. This is why it is strongly suggested that mentors set clear expectations with their mentees around consistent meeting times.
 
-### When to Check In
+The relationship a student builds with their mentor is incredibly valuable, and they may need clear and direct encouragement from you, their mentor, that it is ok to regularly prioritize time spent working with and talking to you.
 
-Instructors post the schedule for the entire module in advance, which can be found on each program’s curriculum site as well as on this site's <a href="/calendars">Calendars</a> and <a href="/module_overviews">Module Overviews</a> sections. Mentors should aim to be conscious of key deadlines that will happen over the course of the module, namely:
+<p>
+  <br>
+</p>
 
-* Project due dates
-* Mid mods
-* Final assessments, evals, and portfolio review
+---
 
-Suggested key conversations that will be beneficial to have with your mentee (templates to guide conversations can be found in the next section):
+## When to Check In
 
-* Week 1: module kick off mentor + mentee DTR
-* Week 3 or 4: mid-mod follow up
-1. What feedback did your instructors give you
-1. What were your areas of struggle/what are your focus areas for the second half of the inning?
-1. What were your strengths?
-* Week 6: module mentor + mentee exit DTR
+Instructors post the schedule for the entire module in advance, which can be found on each program’s curriculum site as well as on this site's <a href="/calendars">Calendars</a> and <a href="/module_overviews">Module Overviews</a> sections. Mentors should aim to be conscious of key deadlines that will happen over the course of the module. You are welcome to touch base as often as you like, but we suggest the below key conversations as key opportunities the will benefit your mentte:
+
+### Most Weeks
+
+- Project due dates
+- Evaluations
+
+### Week 1
+
+- Kick-off Mentor + Mentee Kick-off DTR
+
+### Week 3/4
+
+- Mid-mod Follow Up
+  - What feedback did your instructors give you
+  - What were your areas of struggle/what are your focus areas for the second half of the inning?
+  - What were your strengths?
+
+### Week 5/6
+
+- Portfolio Reviews
+- Mentor + Mentee Exit DTR

--- a/stylesheets/styles-2017121801.scss
+++ b/stylesheets/styles-2017121801.scss
@@ -14,3 +14,4 @@
 @import 'content';
 @import 'buttons';
 @import 'home-page';
+@import 'dtr';


### PR DESCRIPTION
## Overview

- Break out contents into individual pages. The current layout is overwhelming and hard to absorb/read.
- Nav items overflow to two lines and are a little too close together

---

## Notes

- I opted for keeping the DTR information to a single page over breaking it out into "individual pages". This was because the mentorship website already has more nav items than any of the other Turing pages and I felt that adding more would be overkill. Using nested sub-pages was also an option, but I thought this might obfuscate valuable information. For these reasons I tried to reorganize the existing content and made small copy edits to reduce verbiage.

---

## Fix

### DTR page

- Updates general flow of information to use more consolidated paragraphs and lists
- Updates some design patterns to match FE repo (e.g. section breaks, anchor tags over buttons, heading size)
- Small copy updates to reduce wordiness in certain sections

### Nav links

- Updates styles to use `max-content` versus `min-content` and adds slight left and right padding
- Updates media query to accommodate mobile view

---

## Screenshots

### DTR

> **Old**
> ![image](https://user-images.githubusercontent.com/24458700/120568299-d63f0400-c3d0-11eb-820c-8f2f9ca3b5e0.png)
> ![image](https://user-images.githubusercontent.com/24458700/120568374-f5d62c80-c3d0-11eb-9fff-6c93a01c9f46.png)

> **New**
> ![image](https://user-images.githubusercontent.com/24458700/120568338-e525b680-c3d0-11eb-9093-5e9af7891176.png)
> ![image](https://user-images.githubusercontent.com/24458700/120568449-1bfbcc80-c3d1-11eb-8570-77f82a9cd902.png)

### Nav links

> **Old**
> ![image](https://user-images.githubusercontent.com/24458700/120568183-a0018480-c3d0-11eb-8cae-367b525bfed5.png)

> **New**
> ![image](https://user-images.githubusercontent.com/24458700/120568258-be678000-c3d0-11eb-828c-713ad0d328cd.png)
