### PR TITLE
Fix link color

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Overview
+
+Brief description of PR
+
+---
+
+## Notes
+
+Any added details to consider (remove if not needed)
+
+---
+
+## Changes
+
+What was the fix that was implemented? What in the code was added/updated?
+
+---
+
+## Screenshots
+
+Remove if not needed

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -45,7 +45,7 @@ img {
   max-width: 100%;
 }
 
-a, a:link, a:visited {
+a {
   border-bottom: 2px solid lighten($medium-gray, 20);
   color: darken($turing-primary, 30);
   text-decoration: none;

--- a/_sass/dtr.scss
+++ b/_sass/dtr.scss
@@ -1,5 +1,6 @@
 .resource a:link,
-.resource a:visited {
+.resource a:visited,
+.resource {
   color: darken($dark-gray, 10%);
   text-decoration: none;
   font-weight: 500;

--- a/dtr/index.md
+++ b/dtr/index.md
@@ -38,7 +38,7 @@ The relationship a student builds with their mentor is incredibly valuable, and 
 
 ## When to Check In
 
-Instructors post the schedule for the entire module in advance, which can be found on each program’s curriculum site as well as on this site's <a href="/calendars">Calendars</a> and <a href="/module_overviews">Module Overviews</a> sections. Mentors should aim to be conscious of key deadlines that will happen over the course of the module. You are welcome to touch base as often as you like, but we suggest the below key conversations as key opportunities the will benefit your mentte:
+Instructors post the schedule for the entire module in advance, which can be found on each program’s curriculum site as well as on this site's <a class="resource" href="/calendars">Calendars</a> and <a class="resource" href="/module_overviews">Module Overviews</a> sections. Mentors should aim to be conscious of key deadlines that will happen over the course of the module. You are welcome to touch base as often as you like, but we suggest the below key conversations as key opportunities the will benefit your mentte:
 
 ### Most Weeks
 


### PR DESCRIPTION
## Overview

- Button links on the landing page had the incorrect color due to a style cascade issue

---

## Changes

- Update link styles in DTR to be localized to that page
- Adds PR Template

---

## Screenshots

> Broken
> ![image](https://user-images.githubusercontent.com/24458700/121817710-32f7b580-cc40-11eb-9e8e-93ec5da537e2.png)

> Fix
> ![image](https://user-images.githubusercontent.com/24458700/121817716-3f7c0e00-cc40-11eb-8f81-8b211ab824ed.png)

