### PR TITLE
Feat/module filtering

### DIFF
--- a/_data/module_overview.json
+++ b/_data/module_overview.json
@@ -1,0 +1,10 @@
+[
+  { "title": "Mod 0", "file": "mod0.html", "id": "mod0" },
+  { "title": "BE 1", "file": "be_mod1.html", "id": "beMod1" },
+  { "title": "BE 2", "file": "be_mod2.html", "id": "beMod2" },
+  { "title": "BE 3", "file": "be_mod3.html", "id": "beMod3" },
+  { "title": "FE 1", "file": "fe_mod1.html", "id": "feMod1" },
+  { "title": "FE 2", "file": "fe_mod2.html", "id": "feMod2" },
+  { "title": "FE 3", "file": "fe_mod3.html", "id": "feMod3" },
+  { "title": "Mod 4", "file": "combined_mod4.html", "id": "mod4" }
+]

--- a/_layouts/partial.html
+++ b/_layouts/partial.html
@@ -1,0 +1,5 @@
+<section>
+  <article>
+    {{content}}
+  </article>
+</section>

--- a/_sass/buttons.scss
+++ b/_sass/buttons.scss
@@ -9,6 +9,7 @@
   text-transform: uppercase;
   padding: 18px 30px 12px;
   margin: 5px;
+  cursor: pointer;
 }
 
 .btn-dark {
@@ -20,7 +21,17 @@
   }
 }
 
+.btn-dark.active {
+  background-color: $turing-secondary;
+  color: $turing-primary;
+}
+
 .btn-light {
   background-color: $light-gray;
   color: $dark-gray;
+}
+
+.btn-light.active {
+  background-color: $turing-primary;
+  color: $turing-secondary;
 }

--- a/_sass/module_overviews.scss
+++ b/_sass/module_overviews.scss
@@ -5,7 +5,7 @@
   @media (max-width: 1100px) {
     grid-template-columns: repeat(4, 1fr);
   }
-  @media (max-width: $phone-width) {
+  @media (max-width: $phone-width + 50) {
     grid-template-columns: repeat(2, 1fr);
   }
 }

--- a/_sass/module_overviews.scss
+++ b/_sass/module_overviews.scss
@@ -1,3 +1,15 @@
+.module-overview-button-container {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(8, 1fr);
+  @media (max-width: 1100px) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+  @media (max-width: $phone-width) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 .project a:link,
 .project a:visited,
 .project {

--- a/module_overviews/be_mod1.md
+++ b/module_overviews/be_mod1.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: partial
 title: Back End Module 1
 ---
 

--- a/module_overviews/be_mod2.md
+++ b/module_overviews/be_mod2.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: partial
 title: Back End Module 2
 ---
 

--- a/module_overviews/be_mod3.md
+++ b/module_overviews/be_mod3.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: partial
 title: Back End Module 3
 ---
 

--- a/module_overviews/combined_mod4.md
+++ b/module_overviews/combined_mod4.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: partial
 title: Combined Module 4
 ---
 

--- a/module_overviews/fe_mod1.md
+++ b/module_overviews/fe_mod1.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: partial
 title: Front End Module 1
 ---
 

--- a/module_overviews/fe_mod2.md
+++ b/module_overviews/fe_mod2.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: partial
 title: Front End Module 2
 ---
 

--- a/module_overviews/fe_mod3.md
+++ b/module_overviews/fe_mod3.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: partial
 title: Front End Module 3
 ---
 

--- a/module_overviews/index.md
+++ b/module_overviews/index.md
@@ -3,26 +3,25 @@ layout: page
 title: Module Overviews
 ---
 
-## Front End 
-
-<section>
-  <a href="/module_overviews/mod0.html" class="btn btn-dark">Mod 0 </a>
-  <a href="/module_overviews/fe_mod1.html" class="btn btn-dark">FE Mod 1 </a>
-  <a href="/module_overviews/fe_mod2.html" class="btn btn-dark">FE Mod 2 </a>
-  <a href="/module_overviews/fe_mod3.html" class="btn btn-dark">FE Mod 3 </a>
-  <a href="/module_overviews/combined_mod4.html" class="btn btn-dark">Combined Mod 4 </a>
+<section class="module-overview-button-container">
+  {% for item in site.data.module_overview %}
+    <button
+      class="btn btn-dark module-selector"
+      data-module="{{ item.id }}"
+      data-file="{{ item.file }}"
+      type="button"
+    >
+      {{ item.title }}
+    </button>
+  {% endfor %}
 </section>
 
-## Backend End 
+<p>
+  <br>
+</p>
 
-<section>
-  <a href="/module_overviews/mod0.html" class="btn btn-dark">Mod 0 </a>
-  <a href="/module_overviews/be_mod1.html" class="btn btn-dark">BE Mod 1 </a>
-  <a href="/module_overviews/be_mod2.html" class="btn btn-dark">BE Mod 2 </a>
-  <a href="/module_overviews/be_mod3.html" class="btn btn-dark">BE Mod 3 </a>
-  <a href="/module_overviews/combined_mod4.html" class="btn btn-dark">Combined Mod 4 </a>
-</section>
+---
 
-
+<div id="content-container"></div>
 
 <script src="/public/js/module-selectors.js"></script>

--- a/module_overviews/mod0.md
+++ b/module_overviews/mod0.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: partial
 title: Module 0
 ---
 ## Instructors

--- a/public/js/module-selectors.js
+++ b/public/js/module-selectors.js
@@ -1,29 +1,35 @@
 $(
   (function () {
-    var modHash = getModHashSelection();
+    const modHash = getModHashSelection();
+    const modButton =
+      modHash &&
+      document.querySelector(`.module-selector[data-module=${modHash}]`);
 
-    if (modHash) {
+    if (modButton) {
       activateButton(modHash);
       updateSelectedContent(modHash);
     }
 
-    $('.module-selector').on('click', function (event) {
+    $('.module-selector').on('click', (event) => {
       event.preventDefault();
 
-      var currentlyActiveButton = getActivatedButton();
+      const currentlyActiveButton = getActivatedButton();
 
       if (currentlyActiveButton) {
         deactivateButton(currentlyActiveButton);
       }
 
-      var newSelection = $(event.target).data('module');
-      activateButton(newSelection);
-      updateUrl(newSelection);
-      updateSelectedContent(newSelection);
+      const newSelection = $(event.target).data('module');
+
+      if (newSelection) {
+        activateButton(newSelection);
+        updateUrl(newSelection);
+        updateSelectedContent(newSelection);
+      }
     });
 
     function getModHashSelection() {
-      var modHash = window.location.hash;
+      const modHash = window.location.hash;
 
       if (!!modHash) {
         return modHash.split('#')[1];
@@ -33,10 +39,10 @@ $(
     }
 
     function updateSelectedContent(moduleSelection) {
-      var contentContainer = document.getElementById('content-container');
-      var activeButton = getActivatedButton(moduleSelection);
+      const contentContainer = document.getElementById('content-container');
+      const activeButton = getActivatedButton(moduleSelection);
 
-      $.get($(activeButton).data('file'), function (data) {
+      $.get($(activeButton).data('file'), (data) => {
         $(contentContainer).html(data);
       });
     }
@@ -54,7 +60,7 @@ $(
     }
 
     function getActivatedButton() {
-      var activeButton = document.querySelector(
+      const activeButton = document.querySelector(
         'button[class*="module-selector active"]'
       );
 

--- a/public/js/module-selectors.js
+++ b/public/js/module-selectors.js
@@ -1,0 +1,68 @@
+$(
+  (function () {
+    var modHash = getModHashSelection();
+
+    if (modHash) {
+      activateButton(modHash);
+      updateSelectedContent(modHash);
+    }
+
+    $('.module-selector').on('click', function (event) {
+      event.preventDefault();
+
+      var currentlyActiveButton = getActivatedButton();
+
+      if (currentlyActiveButton) {
+        deactivateButton(currentlyActiveButton);
+      }
+
+      var newSelection = $(event.target).data('module');
+      activateButton(newSelection);
+      updateUrl(newSelection);
+      updateSelectedContent(newSelection);
+    });
+
+    function getModHashSelection() {
+      var modHash = window.location.hash;
+
+      if (!!modHash) {
+        return modHash.split('#')[1];
+      }
+
+      return undefined;
+    }
+
+    function updateSelectedContent(moduleSelection) {
+      var contentContainer = document.getElementById('content-container');
+      var activeButton = getActivatedButton(moduleSelection);
+
+      $.get($(activeButton).data('file'), function (data) {
+        $(contentContainer).html(data);
+      });
+    }
+
+    function activateButton(modeSearchQuery) {
+      $(`.module-selector[data-module=${modeSearchQuery}]`).addClass('active');
+    }
+
+    function deactivateButton(currentlyActiveButton) {
+      $(
+        `.module-selector[data-module=${$(currentlyActiveButton).data(
+          'module'
+        )}]`
+      ).removeClass('active');
+    }
+
+    function getActivatedButton() {
+      var activeButton = document.querySelector(
+        'button[class*="module-selector active"]'
+      );
+
+      return activeButton;
+    }
+
+    function updateUrl(newSelection) {
+      window.location.hash = `#${newSelection}`;
+    }
+  })()
+);


### PR DESCRIPTION
## Overview

This updates the "Module Overview" section to use a similar UI/UX to the [FE curriculum "Projects" page](https://frontend.turing.edu/projects/). This is done through the use of a JSON object for all module resources and a JS script (also modeled after the [FE repo](https://github.com/turingschool/front-end-curriculum/blob/gh-pages/public/js/module-selectors.js)) that identifies which module is selected through a hash URL. The UI has also been updated to consolidate all resource buttons into one group to reduce unnecessary noise and simplify selection.

- [Trello Issue](https://trello.com/c/V92c1hNk/9-module-overviews-conditionally-rendered-resources)

---

## Notes

- A hash URL is used to fulfill the requirement that module resources should be directly accessible. A high-level overview of the logic is:
  - When the page loads, if no hash is present, no module is selected and no button is activated. An edge case for a hash being present _without_ a matching module is also considered here.
  - When the page loads, if a hash is present a method grabs it, finds the corresponding button, and adds active styles. It also injects the matching HTML document into a `div` container.
  - When a new module is selected, the previously selected button is deactivated, after which the above scenario for "activation" is repeated for the new module.
  - Example of URL: `https://mentorship.turing.edu/module_overviews#mod0`

---

## Changes

- Adds `module_overviews.json` and `module-selectors.js` to dynamically determine what (if any) module is currently selected
- Builds `partial` layout template
- Updates `module_overviews/index.md` to consolidate all resources onto a single page with a central filtering/selection control
- Updates all `modues_overviews` Markdown files to use `layout: partial`
- Adds active button styling from FE repo

---

## Screenshots

> UX GIF (attention to URL with hash updates)
![Module_Overview_UX](https://user-images.githubusercontent.com/24458700/123874735-d8c04b00-d8f5-11eb-84aa-c9d12392e4d2.gif)

> Desktop UI
![image](https://user-images.githubusercontent.com/24458700/123874803-f2619280-d8f5-11eb-8417-d83bd539a006.png)

> Tablet UI (iPad)
![image](https://user-images.githubusercontent.com/24458700/123874942-1ae98c80-d8f6-11eb-91ba-919a11b592b2.png)

> Mobile UI (iPhone 6/7/8)
![image](https://user-images.githubusercontent.com/24458700/123874894-0c9b7080-d8f6-11eb-9b9e-ef0edaf9b5ed.png)
